### PR TITLE
Nerf issuer

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@
 
 <<: *meta
 name:                lorentz-contract-whitelist
-version:             0.3.0.0
+version:             0.4.0.0
 github:              "tqtezos/lorentz-contract-whitelist"
 license:             BSD3
 author:              "Michael J. Klein TQ Tezos"

--- a/src/Lorentz/Contracts/Whitelist/Types.hs
+++ b/src/Lorentz/Contracts/Whitelist/Types.hs
@@ -234,16 +234,6 @@ assertUserWhitelist = do
   userWhitelist
   assertSome $ mkMTextUnsafe "User not on a whitelist"
 
--- | Assert that the users are on whitelists
-assertUsersWhitelist :: (NiceComparable a, IsComparable a)
-  => a & a & Users a & s :-> WhitelistId & WhitelistId & s
-assertUsersWhitelist = do
-  dip $ do
-    dip dup
-    assertUserWhitelist
-    swap
-  assertUserWhitelist
-
 -- | Specialized `update`
 setOutboundWhitelists :: forall s. ()
   => WhitelistId & Maybe OutboundWhitelists & Whitelists & s :-> Whitelists & s
@@ -272,7 +262,7 @@ assertUnrestrictedOutboundWhitelists = do
 -- @
 --  user & issuer & users & whitelists
 -- @
-assertReceiver :: forall a s. (NiceComparable a, IsComparable a)
+assertReceiver :: forall a s. (NiceComparable a, IsComparable a) -- (NiceComparable a) is not actually redundant
   => a & a & Users a & Whitelists & s :-> a & Users a & Whitelists & s
 assertReceiver = do
   swap

--- a/src/Lorentz/Contracts/Whitelist/Types.hs
+++ b/src/Lorentz/Contracts/Whitelist/Types.hs
@@ -283,7 +283,10 @@ assertReceiver = do
     dip dup
     eq
     if_ -- user is issuer
-       drop
+       (do
+         push $ mkMTextUnsafe "issuer not receiver"
+         failWith
+       )
        (do
          dip dup
          assertUserWhitelist

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -5,6 +5,5 @@ import Tree (tests)
 
 main :: IO ()
 main = do
-  putStrLn "hi!"
   tests >>= defaultMain
 

--- a/test/Test/Whitelist.hs
+++ b/test/Test/Whitelist.hs
@@ -80,6 +80,14 @@ test_AssertTransfer = testGroup "AssertTransfer"
       genesisAddress1 [(genesisAddress3, 0)] [(0, (True, [0]))] genesisAddress2 genesisAddress3 genesisAddress3
   , assertTransfer "Assert transfer from whitelisted user to self (on own whitelist, restricted)" shouldFail
       genesisAddress1 [(genesisAddress3, 0)] [(0, (False, [0]))] genesisAddress2 genesisAddress3 genesisAddress3
+  , assertTransfer "Assert transfer from whitelisted user to other user on same whitelist (no outbound)" shouldFail
+      genesisAddress1 [(genesisAddress3, 0), (genesisAddress4, 0)] [(0, (True, []))] genesisAddress2 genesisAddress3 genesisAddress4
+  , assertTransfer "Assert transfer from whitelisted user to other user on same whitelist (with outbound)" shouldSucceed
+      genesisAddress1 [(genesisAddress3, 0), (genesisAddress4, 0)] [(0, (True, [0]))] genesisAddress2 genesisAddress3 genesisAddress4
+  , assertTransfer "Assert transfer from whitelisted user to other user on other whitelist (no outbound)" shouldFail
+      genesisAddress1 [(genesisAddress3, 0), (genesisAddress4, 1)] [(0, (True, [])), (1, (True, []))] genesisAddress2 genesisAddress3 genesisAddress4
+  , assertTransfer "Assert transfer from whitelisted user to other user on other whitelist (with outbound)" shouldSucceed
+      genesisAddress1 [(genesisAddress3, 0), (genesisAddress4, 1)] [(0, (True, [1])), (1, (True, []))] genesisAddress2 genesisAddress3 genesisAddress4
   ]
 
 assertTransfers :: ()

--- a/test/Test/Whitelist.hs
+++ b/test/Test/Whitelist.hs
@@ -68,7 +68,7 @@ test_AssertTransfer :: TestTree
 test_AssertTransfer = testGroup "AssertTransfer"
   [ assertTransfer "Assert transfer with no users" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 genesisAddress3 genesisAddress4
-  , assertTransfer "Assert transfer from issuer with no users" shouldSucceed
+  , assertTransfer "Assert transfer from issuer with no users" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 genesisAddress1 genesisAddress1
   , assertTransfer "Assert transfer from admin with no users" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 genesisAddress2 genesisAddress2
@@ -109,11 +109,11 @@ test_AssertTransfers :: TestTree
 test_AssertTransfers = testGroup "AssertTransfers"
   [ assertTransfers "Assert transfer with no users" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 [(genesisAddress3, genesisAddress4)]
-  , assertTransfers "Assert transfer from issuer with no users" shouldSucceed
+  , assertTransfers "Assert transfer from issuer with no users" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 [(genesisAddress1, genesisAddress1)]
-  , assertTransfers "Assert transfer from issuer with no users (2x)" shouldSucceed
+  , assertTransfers "Assert transfer from issuer with no users (2x)" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 $ replicate 2 (genesisAddress1, genesisAddress1)
-  , assertTransfers "Assert transfer from issuer with no users (3x)" shouldSucceed
+  , assertTransfers "Assert transfer from issuer with no users (3x)" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 $ replicate 3 (genesisAddress1, genesisAddress1)
   , assertTransfers "Assert transfer from admin with no users" shouldFail
       genesisAddress1 mempty mempty genesisAddress2 [(genesisAddress2, genesisAddress2)]
@@ -157,7 +157,8 @@ test_AssertReceiver = testGroup "AssertReceiver"
         mempty
         genesisAddress2 $ \whitelistContract' -> do
           lCall whitelistContract' $ Whitelist.AssertReceiver genesisAddress1
-          validate . Right $ expectAnySuccess
+          validate . Left $
+            lExpectMichelsonFailed (const True) whitelistContract'
   , testCase "Assert receiver admin with no users" $ do
       withWhitelistContract
         genesisAddress1
@@ -174,7 +175,8 @@ test_AssertReceiver = testGroup "AssertReceiver"
         [(0, (True, []))]
         genesisAddress2 $ \whitelistContract' -> do
           lCall whitelistContract' $ Whitelist.AssertReceiver genesisAddress1
-          validate . Right $ expectAnySuccess
+          validate . Left $
+            lExpectMichelsonFailed (const True) whitelistContract'
   , testCase "Assert receiver on whitelisted user (not on own whitelist)" $ do
       withWhitelistContract
         genesisAddress1
@@ -220,7 +222,8 @@ test_AssertReceivers = testGroup "AssertReceivers"
         mempty
         genesisAddress2 $ \whitelistContract' -> do
           lCall whitelistContract' $ Whitelist.AssertReceivers . return $ genesisAddress1
-          validate . Right $ expectAnySuccess
+          validate . Left $
+            lExpectMichelsonFailed (const True) whitelistContract'
   , testCase "Assert receivers admin with no users" $ do
       withWhitelistContract
         genesisAddress1
@@ -237,7 +240,8 @@ test_AssertReceivers = testGroup "AssertReceivers"
         [(0, (True, []))]
         genesisAddress2 $ \whitelistContract' -> do
           lCall whitelistContract' $ Whitelist.AssertReceivers . return $ genesisAddress1
-          validate . Right $ expectAnySuccess
+          validate . Left $
+            lExpectMichelsonFailed (const True) whitelistContract'
   , testCase "Assert receivers on whitelisted user (not on own whitelist)" $ do
       withWhitelistContract
         genesisAddress1
@@ -274,18 +278,18 @@ test_AssertReceivers = testGroup "AssertReceivers"
   , testCase "Assert receivers with multiple valid" $ do
       withWhitelistContract
         genesisAddress1
-        mempty
-        mempty
+        [(genesisAddress3, 0)]
+        [(0, (True, []))]
         genesisAddress2 $ \whitelistContract' -> do
-          lCall whitelistContract' $ Whitelist.AssertReceivers $ replicate 10 genesisAddress1
+          lCall whitelistContract' $ Whitelist.AssertReceivers $ replicate 10 genesisAddress3
           validate . Right $ expectAnySuccess
   , testCase "Assert receivers with multiple valid and one invalid" $ do
       withWhitelistContract
         genesisAddress1
-        mempty
-        mempty
+        [(genesisAddress3, 0)]
+        [(0, (True, []))]
         genesisAddress2 $ \whitelistContract' -> do
-          lCall whitelistContract' $ Whitelist.AssertReceivers $ replicate 10 genesisAddress1 ++ [genesisAddress3]
+          lCall whitelistContract' $ Whitelist.AssertReceivers $ replicate 10 genesisAddress3 ++ [genesisAddress4]
           validate . Left $
             lExpectMichelsonFailed (const True) whitelistContract'
   ]


### PR DESCRIPTION
Issuer:
- is no longer a receiver (and can't be made one)
- can now only transfer to whitelisted users